### PR TITLE
fix docker-hub image location

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ services:
       - dynamodb
 
   dynamodb:
-    image: azza-bazoo/dynamodb-local
+    image: dabosq/dynamodb-local
 
 ```


### PR DESCRIPTION
When pulling the image from docker-hub, using `azza-bazoo/dynamodb-local` results in image not found.